### PR TITLE
Automate Dependabot PRs: weekly groups + CI build + auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,22 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Amsterdam"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Amsterdam"
+    groups:
+      actions-minor-and-patch:
+        update-types: ["minor", "patch"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,21 @@
+name: Dependabot CI & Auto-Merge
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    if: github.actor == 'dependabot[bot]'
+    uses: preprio/.github/.github/workflows/node-build.yml@main
+    with:
+      node-version: "20"
+      package-manager: "npm"
+      build-command: "npm run build"
+      run-tests: true
+      test-command: "npm run check"
+
+  auto-merge:
+    needs: build
+    if: github.actor == 'dependabot[bot]'
+    uses: preprio/.github/.github/workflows/dependabot-auto-merge.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Updates `dependabot.yml` to weekly schedule (Monday 06:00 CET) with grouped minor+patch bumps — reduces PR volume from daily-per-package to ~2-3 PRs/week
- Adds `.github/workflows/dependabot-auto-merge.yml`: runs a build CI check on Dependabot PRs, then enables auto-merge for patch and minor updates once the build passes
- Major version bumps get labeled `needs-review` + `major-bump` and stay open for manual review

Shared reusable workflows (`node-build.yml`, `dependabot-auto-merge.yml`) live in `preprio/.github` — see [preprio/.github PR #5](https://github.com/preprio/.github/pull/5). **Merge that PR to `main` before merging these.**

## After merging

For auto-merge to work, enable these repo settings:
1. Settings → General → "Allow auto-merge" ✓
2. Settings → Branches → Add branch protection rule for `main` → require status check `build / build`
3. Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests" ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)