### PR TITLE
chore(security): fix CVEs (2026-05-12)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 				"@fontsource/fira-mono": "^4.5.10",
 				"@neoconfetti/svelte": "^1.0.0",
 				"@sveltejs/adapter-auto": "^3.3.1",
-				"@sveltejs/kit": "^2.58.0",
+				"@sveltejs/kit": "^2.59.0",
 				"@types/cookie": "^0.5.4",
 				"svelte": "^5.55.5",
 				"svelte-check": "^3.8.6",
@@ -448,9 +448,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.58.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.58.0.tgz",
-			"integrity": "sha512-kT9GCN8yJTkCK1W+Gi/bvGooWAM7y7WXP+yd+rf6QOIjyoK1ERPrMwSufXJUNu2pMWIqruhFvmz+LbOqsEmKmA==",
+			"version": "2.59.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.59.0.tgz",
+			"integrity": "sha512-WeJaGKvDf3uVQB4bnDHhM+BXCY34LC1v0HiPqnSpvNkjB54r8DAUP1rpk73s+5zprIirEKtUcVfgh6+fPODjzQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"@fontsource/fira-mono": "^4.5.10",
 		"@neoconfetti/svelte": "^1.0.0",
 		"@sveltejs/adapter-auto": "^3.3.1",
-		"@sveltejs/kit": "^2.58.0",
+		"@sveltejs/kit": "^2.59.0",
 		"@types/cookie": "^0.5.4",
 		"svelte": "^5.55.5",
 		"svelte-check": "^3.8.6",


### PR DESCRIPTION
## Security & dependency fixes — 2026-05-12

### Dependabot version bumps

| Package | From | To | Summary |
|---------|------|----|---------|
| @sveltejs/kit | 2.58.0 | 2.59.0 | Minor bump |

> Major bumps (@fontsource/fira-mono 4→5, @neoconfetti/svelte 1→2, typescript 5→6, @types/cookie 0→1) listed in CVE manual review report.
