### PR TITLE
chore(security): fix CVEs (2026-05-26)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
-	"name": "svelte-quick-start",
+	"name": "svelte",
 	"version": "0.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "svelte-quick-start",
+			"name": "svelte",
 			"version": "0.0.1",
 			"devDependencies": {
 				"@fontsource/fira-mono": "^5.2.7",
 				"@neoconfetti/svelte": "^2.2.2",
 				"@sveltejs/adapter-auto": "^3.3.1",
-				"@sveltejs/kit": "^2.60.1",
+				"@sveltejs/kit": "^2.61.1",
 				"@types/cookie": "^1.0.0",
 				"svelte": "^5.55.7",
 				"svelte-check": "^3.8.6",
@@ -454,16 +454,16 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.60.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.60.1.tgz",
-			"integrity": "sha512-mQjlkNo+rJvpln7V2IGY2j99BqhcFbS4UN0AQNKNYfhBAFZTuCDAdW3a1sgf330mvtNvsBXn3HpAhcmvdJTcIQ==",
+			"version": "2.61.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.61.1.tgz",
+			"integrity": "sha512-Ny8s1SR1TyQS2hD2Rvw0XKzU2Nw1eUF52dTb6T2bdcgz7wSC+Nyb5IwjWYlR4b2dvbbR5NJDiQwHg3rnNseghg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
-				"@sveltejs/acorn-typescript": "^1.0.5",
+				"@sveltejs/acorn-typescript": "^1.0.9",
 				"@types/cookie": "^0.6.0",
-				"acorn": "^8.14.1",
+				"acorn": "^8.16.0",
 				"cookie": "^0.6.0",
 				"devalue": "^5.8.1",
 				"esm-env": "^1.2.2",
@@ -501,27 +501,6 @@
 			"integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-7.0.0.tgz",
-			"integrity": "sha512-ILXmxC7HAsnkK2eslgPetrqqW1BKSL7LktsFgqzNj83MaivMGZzluWq32m25j2mDOjmSKX7GGWahePhuEs7P/g==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"deepmerge": "^4.3.1",
-				"magic-string": "^0.30.21",
-				"obug": "^2.1.0",
-				"vitefu": "^1.1.2"
-			},
-			"engines": {
-				"node": "^20.19 || ^22.12 || >=24"
-			},
-			"peerDependencies": {
-				"svelte": "^5.46.4",
-				"vite": "^8.0.0-beta.7 || ^8.0.0"
-			}
 		},
 		"node_modules/@tybys/wasm-util": {
 			"version": "0.10.2",
@@ -717,17 +696,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/deepmerge": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/detect-indent": {
@@ -1335,18 +1303,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/obug": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
-			"dev": true,
-			"funding": [
-				"https://github.com/sponsors/sxzz",
-				"https://opencollective.com/debug"
-			],
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1872,27 +1828,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/vitefu": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
-			"integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"workspaces": [
-				"tests/deps/*",
-				"tests/projects/*",
-				"tests/projects/workspace/packages/*"
-			],
-			"peerDependencies": {
-				"vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"vite": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"@fontsource/fira-mono": "^5.2.7",
 		"@neoconfetti/svelte": "^2.2.2",
 		"@sveltejs/adapter-auto": "^3.3.1",
-		"@sveltejs/kit": "^2.60.1",
+		"@sveltejs/kit": "^2.61.1",
 		"@types/cookie": "^1.0.0",
 		"svelte": "^5.55.7",
 		"svelte-check": "^3.8.6",


### PR DESCRIPTION
## Security & dependency fixes — 2026-05-26

Automatically applied by `/cve-fix`. Patch and minor bumps only.

### Dependabot version bumps

| Package | From | To | Summary |
|---------|------|----|---------|
| @sveltejs/kit | 2.60.1 | 2.61.1 | chore(deps-dev): bump @sveltejs/kit from 2.60.1 to 2.61.1 |

> Major bumps requiring manual review are listed in the [CVE manual review report](/Users/kevinquaedvlieg/Code/prepr/cve-manual-review-2026-05-26.md).
